### PR TITLE
remove select() timeout (it was set to 0s)

### DIFF
--- a/ldpl_net_server/ldpl_net_server.cpp
+++ b/ldpl_net_server/ldpl_net_server.cpp
@@ -96,16 +96,12 @@ int opt = TRUE;
 int master_socket, addrlen, new_socket, max_clients = MAXCLIENTS, activity, i , valread, sd;
 int max_sd; 
 struct sockaddr_in address;
-struct timeval tv;
 
 void LDPL_NET_USEPOLLING(){
     polling = true;
 }
 
 void LDPL_NET_POLL(){
-    tv.tv_sec = 0;
-    tv.tv_usec = 0;
-
 	//clear the socket set 
 	FD_ZERO(&readfds); 
 
@@ -130,7 +126,7 @@ void LDPL_NET_POLL(){
 
 	//wait for an activity on one of the sockets , timeout is NULL , 
 	//so wait indefinitely 
-	activity = select( max_sd + 1 , &readfds , NULL , NULL , &tv); 
+	activity = select( max_sd + 1 , &readfds , NULL , NULL , NULL); 
 
 	if ((activity < 0) && (errno!=EINTR)) 
 	{ 


### PR DESCRIPTION
You can test this with `net_template_polling.lpdl`. If you uncomment the `display "I'm polling"` line, it'll print that statement infinitely because the `select()` timeout is set to 0s, meaning it returns immediately. Using `NULL` and removing the `timeval` code makes it blocking, so you'll only see `I'm polling` print once until it gets a message. At least that's how it works for me, but the NULL should be universal on POSIX.