### PR TITLE
`NET POLL FOR n SECONDS` and `NET POLL BLOCKING`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ This library adds five new statements to the language:
    the execution of your program. You will need to use `NET POLL` to listen for client
    activity. When your program exits, the socket is closed.
 - `NET POLL`
-   - Use this statement to listen for client activity when your server has been started
-   using `NET START ON <number>`.
+   - Use this statement to listen for client activity when your server has been started 
+   using `NET START ON <number>`. By default the call is nonblocking and returns 
+   instantly if there is no activity, but you can set a timeout or wait forever using
+   `NET POLL FOR <number> SECONDS` or `NET POLL BLOCKING`.
 - `NET SEND <text> TO <socket number>`
    - Use this statement send the message `<text>` to the client identified by the
    socket number `<socket number>`. The client will receive your message, easy as pie.

--- a/ldpl_net_server/ldpl_net_server.ldpl
+++ b/ldpl_net_server/ldpl_net_server.ldpl
@@ -5,6 +5,7 @@ data:
     LDPL_NET_IP is external text
     LDPL_NET_PORT is external number
     LDPL_NET_SN is external number #SN is "Socket Number"
+    LDPL_NET_TIMEOUT is external number
 
     ldpl.net.msg is text
     ldpl.net.ip is text
@@ -52,9 +53,23 @@ end sub
 create statement "NET START ON $" executing ldpl.net.startPoll
 
 sub ldpl.net.poll
+parameters:
+    timeout is number
+procedure:
+    store timeout in LDPL_NET_TIMEOUT
     call external LDPL_NET_POLL
 end sub
-create statement "NET POLL" executing ldpl.net.poll
+create statement "NET POLL FOR $ SECONDS" executing ldpl.net.poll
+
+sub ldpl.net.poll-no-timeout
+    call ldpl.net.poll with 0
+end sub
+create statement "NET POLL" executing ldpl.net.poll-no-timeout
+
+sub ldpl.net.poll-blocking
+    call ldpl.net.poll with -1
+end sub
+create statement "NET POLL BLOCKING" executing ldpl.net.poll-blocking
 
 sub ldpl.net.send
     parameters:


### PR DESCRIPTION
Adds two new flavors of `NET POLL` to allow blocking polling or polling without a timeout. Based on the discussion in #2. 

You can test this with the [net_template_polling.ldpl](https://github.com/Lartu/ldpl-net-server/blob/master/net_template_polling.ldpl) demo by uncommenting line 49 and changing line 50 to one of the new statements. 